### PR TITLE
joinTo should filter out templates based on a regex or callable function

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Example:
 
 **NOTE: In order for this plugin to recognize templates, they must have a .tpl.html extension.**
 
-The following example will create a single JavaScript file called templates-app.js in the public/js directory with an Angular module named 'templates-app', which will automatically load up all the templates located in the app/scripts/ directory.  To keep things simple, the module name will always match the name of the concatenated file.  By setting the base in the plugin, the templates can be referenced starting from that directory.  For example, if your template is in app/scripts/somedir/myTemplate.tpl.html, you can reference the template as 'somedir/myTemplate.tpl.html' by setting the base to 'app/scripts'. Furthermore, the templates can be run through html-minifier removing all comments by setting the htmlmin option with the removeComments set to true.
+The following example will create a single JavaScript file called templates-app.js in the public/js directory with an Angular module named 'templates-app', which will automatically load up all the templates located in the app/scripts/ directory.  By default, the module name will match the name of the concatenated file.  By setting the base in the plugin, the templates can be referenced starting from that directory.  For example, if your template is in app/scripts/somedir/myTemplate.tpl.html, you can reference the template as 'somedir/myTemplate.tpl.html' by setting the base to 'app/scripts'. Furthermore, the templates can be run through html-minifier removing all comments by setting the htmlmin option with the removeComments set to true.
 
 ```JavaScript
 files: {
@@ -67,7 +67,7 @@ Language of the output file. Possible values: `'coffee'`, `'js'`.
 Type: `Character`
 Default value: `"`
 
-Strings are quoted with double-quotes by default.  However, for projects 
+Strings are quoted with double-quotes by default.  However, for projects
 that want strict single quote-only usage, you can specify:
 
 ```
@@ -90,7 +90,7 @@ options: { indentString: '    ' }
 to get, for example, 4-space indents. Same goes for tabs or any other
 indent system you want to use.
 
-#### useStrict: 
+#### useStrict:
 Type: `Boolean`
 Default value: ``
 
@@ -100,6 +100,13 @@ module.  Useful for global strict jshint settings.
 ```
 options: { useStrict: true }
 ```
+
+#### moduleName:
+Type: `String`
+Default value: `null`
+
+If not set, the module name will match the name of the concatenated file.
+
 
 #### htmlmin:
 Type: `Object`

--- a/html2js.js
+++ b/html2js.js
@@ -14,8 +14,8 @@ module.exports = function() {
         var moduleName = normalizePath(pathUtils.relative(options.base, path));
 
         //Hack to not include any files not in the app dir since brunch passes in every file matching the extension
-        if (moduleName.indexOf('..') == -1) {
-            this.moduleNames.push("'" + moduleName + "'");
+        if (moduleName.indexOf('..') === -1) {
+            this.moduleNames[path] = "'" + moduleName + "'";
 
             if (options.target === 'js') {
                 return callback(null, compileTemplate(moduleName, content, options.quoteChar, options.indentString, options.useStrict, options.htmlmin));
@@ -32,40 +32,58 @@ module.exports = function() {
     Html2Js.prototype.onCompile = function(generatedFiles) {
         var bundle = '';
         var options = this.options;
-        var joinToKeys = Object.keys(this.joinTo);
 
-        for (var i = 0; i < joinToKeys.length; i++) {
-            var path = this.publicPath + pathUtils.sep + joinToKeys[i];
+        function passesFilter(filter, modulePath) {
+            // filter may either be a regex or callable function
+            if (filter.test !== undefined) {
+                return filter.test(modulePath);
+            } else {
+                return filter(modulePath);
+            }
+        }
+
+        for (var key in this.joinTo) {
+            var path = this.publicPath + pathUtils.sep + key;
             var targetModule = pathUtils.basename(path, '.js');
-            bundle = "angular.module('" + targetModule + "', [" + this.moduleNames.join(', ') + "])";
+            var filter = this.joinTo[key];
+
+            var moduleNameVals = [];
+
+            for (var modulePath in this.moduleNames) {
+                if (passesFilter(filter, modulePath)) {
+                    moduleNameVals.push(this.moduleNames[modulePath]);
+                }
+            }
+
+            bundle = "angular.module('" + targetModule + "', [" + moduleNameVals.join(', ') + "])";
             if (options.target === 'js') {
                 bundle += ';';
             }
 
             bundle += '\n\n';
 
-            var fileContent = fs.readFileSync(path, {encoding: 'utf-8'});            
+            var fileContent = fs.readFileSync(path, {encoding: 'utf-8'});
 
-            if (fileContent.indexOf(bundle) == -1) {
+            if (fileContent.indexOf(bundle) === -1) {
                 fs.writeFile(path, bundle.concat(fileContent), function(err) {
                     if (err) throw err;
                 });
             }
         }
-    }
+    };
 
     function Html2Js(cfg) {
         cfg = cfg || {};
         this.options = {
-            base: 'src',            
-            quoteChar: '"',           
+            base: 'src',
+            quoteChar: '"',
             indentString: '    ',
             target: 'js',
             htmlmin: {}
         };
         this.joinTo = cfg.files ? cfg.files.templates.joinTo : null;
         this.publicPath = cfg.paths ? cfg.paths.public : null;
-        this.moduleNames = [];
+        this.moduleNames = {};
 
         var config = cfg.plugins && cfg.plugins.html2js;
         if (config) {

--- a/html2js.js
+++ b/html2js.js
@@ -44,7 +44,7 @@ module.exports = function() {
 
         for (var key in this.joinTo) {
             var path = this.publicPath + pathUtils.sep + key;
-            var targetModule = pathUtils.basename(path, '.js');
+            var targetModule = this.options.moduleName || pathUtils.basename(path, '.js');
             var filter = this.joinTo[key];
 
             var moduleNameVals = [];
@@ -79,6 +79,7 @@ module.exports = function() {
             quoteChar: '"',
             indentString: '    ',
             target: 'js',
+            moduleName: null,
             htmlmin: {}
         };
         this.joinTo = cfg.files ? cfg.files.templates.joinTo : null;


### PR DESCRIPTION
It doesn't seem that the regex/callable in the joinTo clause works properly. E.g.

```
templates: {
    joinTo: {
        'templates-app.js': /^app/,
        'templates-common.js': /^common/,
        'templates-admin.js': function(path) {
            return /^admin/.test(path);
        }
    }
}
```

This seems to work as far as filtering out the correct tpl.html files to include, but the top angular.module that gets prepended to the file includes **every** module, not just the filtered modules.

I'm new to brunch so I don't know if there's a simpler patch, but this seems to work for me.
